### PR TITLE
fix: add repository.repo check to the context.payload condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function sleep(seconds) {
 }
 
 function repo() {
-  if (github.context.payload.repository) {
+  if (github.context.payload.repository && github.context.payload.repository.owner) {
     return {
       owner: github.context.payload.repository.owner.login,
       name: github.context.payload.repository.name


### PR DESCRIPTION
Added a check for `owner` to the condition that makes sure `repository` is not undefined in `context.payload` to fix the undefined repository error when used in a scheduled action